### PR TITLE
feat: allow callers to override the value of the shortopts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,10 @@ lint: ## Run all linters
 	@echo "+ $@"
 	tox -e linters
 
+.PHONY: test
+test: tests ## Run unit tests
+	@echo "+ $@"
+
 .PHONY: tests
 tests: unit-tests
 	@echo "+ $@"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.7.0
+current_version = 0.8.0
 commit = True
 tag = False
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ TEST_REQUIREMENTS = ["pytest"]
 
 setup(
     name="yamkix",
-    version="0.7.0",
+    version="0.8.0",
     author="Christophe Furmaniak",
     author_email="christophe.furmaniak@gmail.com",
     description="An opinionated yaml formatter based on ruamel.yaml",

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -2,8 +2,8 @@
 import unittest
 
 from yamkix.args import (
-    parse_cli,
     get_override_or_default,
+    parse_cli,
 )
 from yamkix.config import (
     get_default_yamkix_config,

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -1,8 +1,14 @@
 """Tests the args parsing."""
 import unittest
 
-from yamkix.args import parse_cli
-from yamkix.config import get_default_yamkix_config, YamkixConfig
+from yamkix.args import (
+    parse_cli,
+    get_override_or_default,
+)
+from yamkix.config import (
+    get_default_yamkix_config,
+    YamkixConfig,
+)
 
 
 class TestArgs(unittest.TestCase):
@@ -31,3 +37,29 @@ class TestArgs(unittest.TestCase):
         )
         self.assertEqual(sut.line_width, yamkix_default_config.line_width)
         self.assertEqual(sut.version, yamkix_default_config.version)
+
+    def test_get_override_or_default_when_key_doesnt_exist(self):
+        """Test get_override_or_default when key doesn't exist."""
+        sut = dict()
+        key = "any"
+        default_value = "yolo"
+        result = get_override_or_default(sut, key, default_value)
+        self.assertEqual(result, default_value)
+
+    def test_get_override_or_default_when_key_exists(self):
+        """Test get_override_or_default when key exists."""
+        sut = dict()
+        key = "i_m_the_one"
+        value_for_key = "yamkix_rulez"
+        default_value = "yolo"
+        sut[key] = value_for_key
+        result = get_override_or_default(sut, key, default_value)
+        self.assertEqual(result, value_for_key)
+
+    def test_get_override_or_default_when_override_is_none(self):
+        """Test get_override_or_default when override is none."""
+        sut = None
+        key = "any"
+        default_value = "yolo"
+        result = get_override_or_default(sut, key, default_value)
+        self.assertEqual(result, default_value)

--- a/yamkix/__init__.py
+++ b/yamkix/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 
 """Top-level package for kubesplit."""
-__version__ = "0.7.0"
+__version__ = "0.8.0"

--- a/yamkix/args.py
+++ b/yamkix/args.py
@@ -9,38 +9,51 @@ from yamkix.config import (
 )
 
 
-def add_yamkix_options_to_parser(parser):
+def get_override_or_default(short_opt_override, key, default_value):
+    """Returns the override to apply or the default value."""
+    if short_opt_override and key in short_opt_override:
+        return short_opt_override[key]
+    return default_value
+
+
+def add_yamkix_options_to_parser(parser, short_opt_override=None):
     """Add yamkix reusable options to a parser object."""
     parser.add_argument(
-        "-t",
+        get_override_or_default(short_opt_override, "--typ", "-t"),
         "--typ",
         required=False,
         default="rt",
         help="the yaml parser mode. Can be `safe` or `rt`",
     )
     parser.add_argument(
-        "-n",
+        get_override_or_default(
+            short_opt_override, "--no-explicit-start", "-n"
+        ),
         "--no-explicit-start",
         action="store_true",
         help="by default, explicit start of the yaml doc \
                                 is `On`, you can disable it with this option",
     )
     parser.add_argument(
-        "-e",
+        get_override_or_default(short_opt_override, "--explicit-end", "-e"),
         "--explicit-end",
         action="store_true",
         help="by default, explicit end of the yaml doc \
                                 is `Off`, you can enable it with this option",
     )
     parser.add_argument(
-        "-q",
+        get_override_or_default(
+            short_opt_override, "--no-quotes-preserved", "-q"
+        ),
         "--no-quotes-preserved",
         action="store_true",
         help="by default, quotes are preserved \
                                 you can disable this with this option",
     )
     parser.add_argument(
-        "-f",
+        get_override_or_default(
+            short_opt_override, "--default-flow-style", "-f"
+        ),
         "--default-flow-style",
         action="store_true",
         help="enable the default flow style \
@@ -49,7 +62,7 @@ def add_yamkix_options_to_parser(parser):
                                 like json",
     )
     parser.add_argument(
-        "-d",
+        get_override_or_default(short_opt_override, "--no-dash-inwards", "-d"),
         "--no-dash-inwards",
         action="store_true",
         help="by default, dash are pushed inwards \
@@ -57,7 +70,9 @@ def add_yamkix_options_to_parser(parser):
                                 start at the sequence level",
     )
     parser.add_argument(
-        "-c",
+        get_override_or_default(
+            short_opt_override, "--spaces-before-comment", "-c"
+        ),
         "--spaces-before-comment",
         default=None,
         help="specify the number of spaces between comments and content. \


### PR DESCRIPTION
because callers may have short opt flag that conflicts with yamkix ones, you can now override the short opt flag when calling `yamkix.args.add_yamkix_options_to_parser`