### PR TITLE
feat(stdin/stdout): ignore case when specifying explicit STDIN/STDOUT

### DIFF
--- a/src/yamkix/config.py
+++ b/src/yamkix/config.py
@@ -342,12 +342,17 @@ def create_yamkix_config_from_typer_args(  # noqa: PLR0913
             for file in files
         ]
     else:
-        f_input = None if (input_file is None or input_file == STDIN_DISPLAY_NAME) else input_file
+        f_input = None if (input_file is None or input_file.lower() == STDIN_DISPLAY_NAME.lower()) else input_file
+        # If stdout is set, then output=STDOUT whatever f_output and f_input values
         if stdout:
             f_output = None
-        elif output_file is not None and output_file != STDOUT_DISPLAY_NAME:
+        # if f_output is not None and not 'stdout' (whatever the case)
+        elif output_file is not None and output_file.lower() != STDOUT_DISPLAY_NAME.lower():
             f_output = output_file
-        elif output_file == STDOUT_DISPLAY_NAME or f_input is None:
+        # if f_output is 'stdout' (whatever the case) or if f_input is None (stdin)
+        elif (output_file is not None and output_file.lower() == STDOUT_DISPLAY_NAME.lower()) or (
+            output_file is None and f_input is None
+        ):
             f_output = None
         else:
             f_output = f_input

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -634,11 +634,19 @@ class TestCreateYamkixConfigFromTyperArgs:
         assert configs[0].io_config.input is None
         assert configs[0].io_config.output is None
 
-    def test_create_yamkix_config_io_logic_with_explicit_stdin_as_input(self) -> None:
+    @pytest.mark.parametrize(
+        "input_file",
+        [
+            pytest.param(STDIN_DISPLAY_NAME, id="STDIN"),
+            pytest.param("StDin", id="StDin"),
+            pytest.param(STDIN_DISPLAY_NAME.lower(), id="stdin"),
+        ],
+    )
+    def test_create_yamkix_config_io_logic_with_explicit_stdin_as_input(self, input_file: str) -> None:
         """Test input/output file logic."""
         # Test case: input set explicitly to STDIN and no output -> output should be None (STDOUT)
         configs = create_yamkix_config_from_typer_args(
-            input_file=STDIN_DISPLAY_NAME,
+            input_file=input_file,
             output_file=None,
             stdout=False,
             typ="rt",
@@ -654,12 +662,20 @@ class TestCreateYamkixConfigFromTyperArgs:
         assert configs[0].io_config.input is None
         assert configs[0].io_config.output is None
 
-    def test_create_yamkix_config_io_logic_with_explicit_stdout_as_output(self) -> None:
+    @pytest.mark.parametrize(
+        "output_file",
+        [
+            pytest.param(STDOUT_DISPLAY_NAME, id="STDOUT"),
+            pytest.param("StDout", id="StDout"),
+            pytest.param(STDOUT_DISPLAY_NAME.lower(), id="stdout"),
+        ],
+    )
+    def test_create_yamkix_config_io_logic_with_explicit_stdout_as_output(self, output_file: str) -> None:
         """Test input/output file logic."""
         # Test case: output is "STDOUT" -> output should be None
         configs = create_yamkix_config_from_typer_args(
             input_file="input.yaml",
-            output_file=STDOUT_DISPLAY_NAME,
+            output_file=output_file,
             stdout=False,
             typ="rt",
             no_explicit_start=False,


### PR DESCRIPTION
# Description

- Fixes #263 