### PR TITLE
feat(core): add --convert-flow-to-block option

### DIFF
--- a/src/yamkix/_cli.py
+++ b/src/yamkix/_cli.py
@@ -162,6 +162,14 @@ def main(  # noqa: PLR0913
             help="align EOL comments within each dict/list to the maximum column.",
         ),
     ] = False,
+    convert_flow_to_block: Annotated[
+        bool,
+        typer.Option(
+            "-b",
+            "--convert-flow-to-block",
+            help="convert flow-style (JSON-style) sequences and mappings to block style.",
+        ),
+    ] = False,
     line_width: Annotated[
         int,
         typer.Option(
@@ -216,6 +224,7 @@ def main(  # noqa: PLR0913
         enforce_double_quotes=enforce_double_quotes,
         line_width=line_width,
         align_comments=align_comments,
+        convert_flow_to_block=convert_flow_to_block,
         files=files,
     )
     console = get_stderr_console()

--- a/src/yamkix/config.py
+++ b/src/yamkix/config.py
@@ -58,6 +58,7 @@ class YamkixConfig:  # pylint: disable=too-many-instance-attributes
         enforce_double_quotes: Whether to enforce double quotes when quotes_preserved is False
         line_width: Maximum line width.
         align_comments: Whether to align EOL comments within each dict/list to the maximum column.
+        convert_flow_to_block: Whether to convert flow-style (JSON-style) collections to block style.
         version: Whether to include version information (deprecated)
         io_config: Input/Output configuration.
 
@@ -73,6 +74,7 @@ class YamkixConfig:  # pylint: disable=too-many-instance-attributes
     enforce_double_quotes: bool
     line_width: int
     align_comments: bool
+    convert_flow_to_block: bool
     version: bool | None
     io_config: YamkixInputOutputConfig
 
@@ -99,6 +101,8 @@ class YamkixConfig:  # pylint: disable=too-many-instance-attributes
             + str(self.line_width)
             + ", align_comments="
             + str(self.align_comments)
+            + ", convert_flow_to_block="
+            + str(self.convert_flow_to_block)
         )
 
 
@@ -118,6 +122,7 @@ def get_default_yamkix_config() -> YamkixConfig:
                 <li><i>spaces_before_comment = None</i></li>
                 <li><i>line_width = 2048</i></li>
                 <li><i>align_comments = False</i></li>
+                <li><i>convert_flow_to_block = False</i></li>
                 <li><i>io_config</i>:
                     <ul>
                         <li><i>input = None</i></li>
@@ -137,6 +142,7 @@ def get_default_yamkix_config() -> YamkixConfig:
         spaces_before_comment=None,
         line_width=DEFAULT_LINE_WIDTH,
         align_comments=False,
+        convert_flow_to_block=False,
         version=False,
         io_config=get_default_yamkix_input_output_config(),
     )
@@ -167,6 +173,7 @@ def get_yamkix_config_from_default(  # noqa: PLR0913
     spaces_before_comment: int | None = None,
     line_width: int | None = None,
     align_comments: bool | None = None,
+    convert_flow_to_block: bool | None = None,
     io_config: YamkixInputOutputConfig | None = None,
 ) -> YamkixConfig:
     """Return a `Yamkix` configuration, based on the default one.
@@ -188,6 +195,7 @@ def get_yamkix_config_from_default(  # noqa: PLR0913
         spaces_before_comment: Number of spaces before comments.
         line_width: Maximum line width.
         align_comments: Whether to align EOL comments within each dict/list to the maximum column.
+        convert_flow_to_block: Whether to convert flow-style (JSON-style) collections to block style.
         io_config: Input/Output configuration.
 
     Returns:
@@ -216,6 +224,9 @@ def get_yamkix_config_from_default(  # noqa: PLR0913
         else default_config.spaces_before_comment,
         line_width=line_width if line_width is not None else default_config.line_width,
         align_comments=align_comments if align_comments is not None else default_config.align_comments,
+        convert_flow_to_block=convert_flow_to_block
+        if convert_flow_to_block is not None
+        else default_config.convert_flow_to_block,
         version=None,
         io_config=io_config if io_config is not None else get_default_yamkix_input_output_config(),
     )
@@ -272,6 +283,7 @@ def get_config_from_args(args: Namespace, inc_io_config: bool = True) -> YamkixC
         io_config=yamkix_input_output_config,
         line_width=default_yamkix_config.line_width,
         align_comments=getattr(args, "align_comments", False),
+        convert_flow_to_block=getattr(args, "convert_flow_to_block", False),
     )
 
 
@@ -329,6 +341,7 @@ def create_yamkix_config_from_typer_args(  # noqa: PLR0913
     spaces_before_comment: int | None,
     line_width: int,
     align_comments: bool,
+    convert_flow_to_block: bool,
     files: list[Path] | None,
 ) -> list[YamkixConfig]:
     """Create a list of YamkixConfig from Typer arguments.
@@ -390,6 +403,7 @@ def create_yamkix_config_from_typer_args(  # noqa: PLR0913
             spaces_before_comment=spaces_before_comment,
             line_width=line_width,
             align_comments=align_comments,
+            convert_flow_to_block=convert_flow_to_block,
             version=None,
             io_config=io_config,
         )

--- a/src/yamkix/helpers.py
+++ b/src/yamkix/helpers.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from rich.console import Console
 from rich.theme import Theme
+from ruamel.yaml.comments import CommentedMap, CommentedSeq
 from ruamel.yaml.scalarstring import DoubleQuotedScalarString, SingleQuotedScalarString
 
 from yamkix.__version__ import __version__
@@ -58,6 +59,22 @@ def get_stdout_console() -> Console:
     """Return the CLI rich console."""
     custom_theme = get_custom_theme()
     return Console(theme=custom_theme, stderr=False)
+
+
+def convert_flow_to_block_style(data: Any) -> None:  # noqa: ANN401
+    """Recursively convert flow-style collections to block style.
+
+    Args:
+        data: The YAML data structure to convert in-place.
+    """
+    if isinstance(data, CommentedMap):
+        data.fa.set_block_style()
+        for value in data.values():
+            convert_flow_to_block_style(value)
+    elif isinstance(data, CommentedSeq):
+        data.fa.set_block_style()
+        for item in data:
+            convert_flow_to_block_style(item)
 
 
 def convert_single_to_double_quotes(

--- a/src/yamkix/yamkix.py
+++ b/src/yamkix/yamkix.py
@@ -15,7 +15,7 @@ from ruamel.yaml.scanner import ScannerError
 from yamkix.comments import align_comments, process_comments
 from yamkix.config import YamkixConfig
 from yamkix.errors import InvalidYamlContentError
-from yamkix.helpers import convert_single_to_double_quotes, strip_leading_double_space
+from yamkix.helpers import convert_flow_to_block_style, convert_single_to_double_quotes, strip_leading_double_space
 from yamkix.yaml_writer import get_opinionated_yaml_writer
 
 
@@ -79,6 +79,7 @@ def round_trip_and_format(yamkix_config: YamkixConfig) -> FileProcessingResult:
         double_quotes_yaml=double_quotes_yaml,
         capture_buffer=output_buffer,
         align_comments_flag=yamkix_config.align_comments,
+        convert_flow_to_block=yamkix_config.convert_flow_to_block,
     )
     unchanged = output_buffer.getvalue() == raw_input
     return FileProcessingResult(
@@ -97,6 +98,7 @@ def yamkix_dump_all(  # noqa: PLR0913
     double_quotes_yaml: YAML | None = None,
     capture_buffer: StringIO | None = None,
     align_comments_flag: bool = False,
+    convert_flow_to_block: bool = False,
 ) -> None:
     """Dump all the documents from the input structure.
 
@@ -111,6 +113,7 @@ def yamkix_dump_all(  # noqa: PLR0913
         capture_buffer: An optional `StringIO` buffer that receives a copy of the dumped output.
             Used by `round_trip_and_format` to detect whether the content was changed.
         align_comments_flag: Whether to align EOL comments within each dict/list to the maximum column.
+        convert_flow_to_block: Whether to convert flow-style (JSON-style) collections to block style.
 
     """
     # Clear the output file if it is a file and it exists
@@ -118,6 +121,8 @@ def yamkix_dump_all(  # noqa: PLR0913
         with output_file_path.open(mode="w", encoding="UTF-8") as _:
             pass
     for doc in one_or_more_items:
+        if convert_flow_to_block:
+            convert_flow_to_block_style(doc)
         # If we have a double_quotes_yaml instance, then proceed to an extra roundtrip
         # the first one, using the `yaml` instance, will remove unnecessary quotes
         # and convert all quotes to single quote

--- a/tests/data/expected/flow-sequences-and-maps--convert-flow-to-block.yml
+++ b/tests/data/expected/flow-sequences-and-maps--convert-flow-to-block.yml
@@ -1,0 +1,17 @@
+---
+a_list:
+  - a
+  - b
+  - c
+a_map:
+  first: yolo
+  second: foo
+nested:
+  inner_list:
+    - x
+    - y
+  inner_map:
+    a: 1
+already_block:
+  - item1
+  - item2

--- a/tests/data/expected/lists-and-maps-json-style--convert-flow-to-block.yml
+++ b/tests/data/expected/lists-and-maps-json-style--convert-flow-to-block.yml
@@ -1,0 +1,6 @@
+---
+a-map:
+  key1: value1
+  key2: value2
+a-json-map:
+  key1: value1

--- a/tests/data/source/flow-sequences-and-maps.yml
+++ b/tests/data/source/flow-sequences-and-maps.yml
@@ -1,0 +1,7 @@
+---
+a_list: [a, b, c]
+a_map: {first: yolo, second: foo}
+nested: {inner_list: [x, y], inner_map: {a: 1}}
+already_block:
+  - item1
+  - item2

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -96,6 +96,7 @@ class TestCli:
             enforce_double_quotes=default_config.enforce_double_quotes,
             line_width=default_config.line_width,
             align_comments=default_config.align_comments,
+            convert_flow_to_block=default_config.convert_flow_to_block,
             files=None,
         )
         mock_print_config.assert_called_once_with(mock_config)
@@ -130,6 +131,7 @@ class TestCli:
             enforce_double_quotes=default_config.enforce_double_quotes,
             line_width=default_config.line_width,
             align_comments=default_config.align_comments,
+            convert_flow_to_block=default_config.convert_flow_to_block,
             files=[test_file],
         )
         mock_print_config.assert_called_once_with(mock_config)
@@ -167,6 +169,7 @@ class TestCli:
             enforce_double_quotes=default_config.enforce_double_quotes,
             line_width=default_config.line_width,
             align_comments=default_config.align_comments,
+            convert_flow_to_block=default_config.convert_flow_to_block,
             files=[test_file1, test_file2],
         )
         mock_print_config.assert_called()
@@ -243,6 +246,7 @@ class TestCli:
             enforce_double_quotes=default_config.enforce_double_quotes,
             line_width=100,
             align_comments=default_config.align_comments,
+            convert_flow_to_block=default_config.convert_flow_to_block,
             files=None,
         )
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -489,6 +489,7 @@ class TestCreateYamkixConfigFromTyperArgs:
             enforce_double_quotes=False,
             line_width=DEFAULT_LINE_WIDTH,
             align_comments=False,
+            convert_flow_to_block=False,
             files=None,
         )
 
@@ -520,6 +521,7 @@ class TestCreateYamkixConfigFromTyperArgs:
             enforce_double_quotes=False,
             line_width=DEFAULT_LINE_WIDTH,
             align_comments=False,
+            convert_flow_to_block=False,
             files=None,
         )
         assert len(configs) == 1
@@ -542,6 +544,7 @@ class TestCreateYamkixConfigFromTyperArgs:
             enforce_double_quotes=False,
             line_width=DEFAULT_LINE_WIDTH,
             align_comments=False,
+            convert_flow_to_block=False,
             files=None,
         )
 
@@ -571,6 +574,7 @@ class TestCreateYamkixConfigFromTyperArgs:
             enforce_double_quotes=False,
             line_width=DEFAULT_LINE_WIDTH,
             align_comments=False,
+            convert_flow_to_block=False,
             files=None,
         )
 
@@ -599,6 +603,7 @@ class TestCreateYamkixConfigFromTyperArgs:
             enforce_double_quotes=False,
             line_width=DEFAULT_LINE_WIDTH,
             align_comments=False,
+            convert_flow_to_block=False,
             files=None,
         )
         assert configs[0].io_config.input == "input.yaml"
@@ -621,6 +626,7 @@ class TestCreateYamkixConfigFromTyperArgs:
             enforce_double_quotes=False,
             line_width=DEFAULT_LINE_WIDTH,
             align_comments=False,
+            convert_flow_to_block=False,
             files=None,
         )
         assert configs[0].io_config.input is None
@@ -643,6 +649,7 @@ class TestCreateYamkixConfigFromTyperArgs:
             enforce_double_quotes=False,
             line_width=DEFAULT_LINE_WIDTH,
             align_comments=False,
+            convert_flow_to_block=False,
             files=None,
         )
         assert configs[0].io_config.input is None
@@ -673,6 +680,7 @@ class TestCreateYamkixConfigFromTyperArgs:
             enforce_double_quotes=False,
             line_width=DEFAULT_LINE_WIDTH,
             align_comments=False,
+            convert_flow_to_block=False,
             files=None,
         )
         assert configs[0].io_config.input is None
@@ -703,6 +711,7 @@ class TestCreateYamkixConfigFromTyperArgs:
             enforce_double_quotes=False,
             line_width=DEFAULT_LINE_WIDTH,
             align_comments=False,
+            convert_flow_to_block=False,
             files=None,
         )
         assert configs[0].io_config.input == "input.yaml"
@@ -725,6 +734,7 @@ class TestCreateYamkixConfigFromTyperArgs:
             enforce_double_quotes=False,
             line_width=DEFAULT_LINE_WIDTH,
             align_comments=False,
+            convert_flow_to_block=False,
             files=[test_file1],
         )
         assert configs[0].io_config.input == str(test_file1)
@@ -749,6 +759,7 @@ class TestCreateYamkixConfigFromTyperArgs:
             enforce_double_quotes=False,
             line_width=DEFAULT_LINE_WIDTH,
             align_comments=False,
+            convert_flow_to_block=False,
             files=input_files,
         )
         assert len(configs) == len(input_files)
@@ -774,6 +785,7 @@ class TestCreateYamkixConfigFromTyperArgs:
                 enforce_double_quotes=False,
                 line_width=DEFAULT_LINE_WIDTH,
                 align_comments=False,
+                convert_flow_to_block=False,
                 files=[],
             )
 
@@ -804,7 +816,7 @@ class TestPrintYamkixConfig:
         expected = (
             "typ=rt, explicit_start=True, explicit_end=False, default_flow_style=False, "
             "quotes_preserved=True, enforce_double_quotes=False, dash_inwards=True, spaces_before_comment=None"
-            ", line_width=2048, align_comments=False"
+            ", line_width=2048, align_comments=False, convert_flow_to_block=False"
         )
         assert result == expected
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,8 +1,12 @@
 """Test helpers."""
 
+from typing import Any
+
+from ruamel.yaml import YAML
 from ruamel.yaml.scalarstring import DoubleQuotedScalarString, SingleQuotedScalarString
 
 from yamkix.helpers import (
+    convert_flow_to_block_style,
     convert_single_to_double_quotes,
     get_yamkix_version,
     remove_all_linebreaks,
@@ -349,3 +353,59 @@ class TestConvertSingleToDoubleQuotes:
         assert result["users"][0]["settings"]["timeout"] == timeout_value
         assert result["users"][1]["tags"][1] == "user"
         assert result["config"]["debug"] is False
+
+
+def _load_yaml(text: str) -> Any:  # noqa: ANN401
+    """Load YAML text using the round-trip loader."""
+    yaml = YAML()
+    return yaml.load(text)
+
+
+class TestConvertFlowToBlockStyle:
+    """Test cases for convert_flow_to_block_style function."""
+
+    def test_flow_sequence_is_converted(self) -> None:
+        """Test that a top-level flow sequence is converted to block style."""
+        data = _load_yaml("a_list: [a, b, c]\n")
+        assert data["a_list"].fa.flow_style() is True
+        convert_flow_to_block_style(data)
+        assert data["a_list"].fa.flow_style() is False
+
+    def test_flow_mapping_is_converted(self) -> None:
+        """Test that a top-level flow mapping is converted to block style."""
+        data = _load_yaml("a_map: {first: yolo, second: foo}\n")
+        assert data["a_map"].fa.flow_style() is True
+        convert_flow_to_block_style(data)
+        assert data["a_map"].fa.flow_style() is False
+
+    def test_nested_flow_structures_are_converted(self) -> None:
+        """Test that nested flow-style sequences and mappings are all converted."""
+        data = _load_yaml("outer: {inner_list: [x, y], inner_map: {a: 1}}\n")
+        assert data["outer"].fa.flow_style() is True
+        convert_flow_to_block_style(data)
+        assert data["outer"].fa.flow_style() is False
+        assert data["outer"]["inner_list"].fa.flow_style() is False
+        assert data["outer"]["inner_map"].fa.flow_style() is False
+
+    def test_already_block_style_is_unchanged(self) -> None:
+        """Test that block-style structures are unaffected."""
+        data = _load_yaml("a_list:\n  - a\n  - b\n")
+        assert data["a_list"].fa.flow_style() is False
+        convert_flow_to_block_style(data)
+        assert data["a_list"].fa.flow_style() is False
+
+    def test_scalar_values_are_not_modified(self) -> None:
+        """Test that scalar values pass through without error."""
+        data = _load_yaml("key: value\n")
+        convert_flow_to_block_style(data)
+        assert data["key"] == "value"
+
+    def test_mixed_document_converts_only_flow_parts(self) -> None:
+        """Test that only flow-style parts of a mixed document are converted."""
+        yaml_text = "block_list:\n  - a\n  - b\nflow_list: [x, y]\n"
+        data = _load_yaml(yaml_text)
+        assert data["block_list"].fa.flow_style() is False
+        assert data["flow_list"].fa.flow_style() is True
+        convert_flow_to_block_style(data)
+        assert data["block_list"].fa.flow_style() is False
+        assert data["flow_list"].fa.flow_style() is False

--- a/tests/test_non_regression.py
+++ b/tests/test_non_regression.py
@@ -164,6 +164,18 @@ class TestNonRegression:
                 [],
                 id="issue_259_01_default_no_align",
             ),
+            pytest.param(
+                "lists-and-maps-json-style",
+                "convert-flow-to-block",
+                ["--convert-flow-to-block"],
+                id="lists_and_maps_json_style_convert_flow_to_block",
+            ),
+            pytest.param(
+                "flow-sequences-and-maps",
+                "convert-flow-to-block",
+                ["--convert-flow-to-block"],
+                id="flow_sequences_and_maps_convert_flow_to_block",
+            ),
         ],
     )
     def test_config(

--- a/tests/test_yamkix.py
+++ b/tests/test_yamkix.py
@@ -1,6 +1,7 @@
 """Provide tests for the yamkix module."""
 
 import sys
+from io import StringIO
 from pathlib import Path
 from textwrap import dedent
 
@@ -134,3 +135,63 @@ class TestYamkixDumpAll:
             out=sys.stdout,
             spaces_before_comment=config.spaces_before_comment,
         )
+
+
+class TestConvertFlowToBlock:
+    """Tests for the convert_flow_to_block feature integrated into yamkix_dump_all."""
+
+    def test_flow_sequences_and_maps_become_block(self, tmp_path: Path) -> None:
+        """Test that flow-style sequences and mappings are converted to block style."""
+        # GIVEN
+        yaml_content = "---\na_list: [a, b, c]\na_map: {first: yolo, second: foo}\n"
+        input_file = tmp_path / "test.yml"
+        input_file.write_text(yaml_content)
+        config = get_yamkix_config_from_default(
+            convert_flow_to_block=True,
+            io_config=YamkixInputOutputConfig(input=str(input_file), output=None),
+        )
+
+        # WHEN
+        result = round_trip_and_format(config)
+
+        # THEN
+        assert result.error is False
+        assert result.unchanged is False
+
+    def test_block_style_unchanged_when_flag_disabled(self, tmp_path: Path) -> None:
+        """Test that flow-style content is preserved when flag is off."""
+        # GIVEN: already-formatted block YAML
+        yaml_content = "---\na_list:\n  - a\n  - b\n  - c\n"
+        input_file = tmp_path / "test.yml"
+        input_file.write_text(yaml_content)
+        config = get_yamkix_config_from_default(
+            convert_flow_to_block=False,
+            io_config=YamkixInputOutputConfig(input=str(input_file), output=None),
+        )
+
+        # WHEN
+        result = round_trip_and_format(config)
+
+        # THEN
+        assert result.error is False
+        assert result.unchanged is True
+
+    def test_yamkix_dump_all_calls_convert_when_flag_set(self) -> None:
+        """Test yamkix_dump_all invokes convert_flow_to_block_style when flag is True."""
+        config = get_default_yamkix_config()
+        yaml_parser = get_opinionated_yaml_writer(config)
+        yaml_content = yaml_parser.load("a_list: [x, y]\n")
+        buf = StringIO()
+        yamkix_dump_all(
+            [yaml_content],
+            yaml_parser,
+            dash_inwards=True,
+            output_file=None,
+            spaces_before_comment=None,
+            capture_buffer=buf,
+            convert_flow_to_block=True,
+        )
+        output = buf.getvalue()
+        assert "[x, y]" not in output
+        assert "- x" in output
+        assert "- y" in output

--- a/tests/test_yaml_writer.py
+++ b/tests/test_yaml_writer.py
@@ -62,6 +62,7 @@ class TestGetOpinionatedYamlWriter:
             line_width=DEFAULT_LINE_WIDTH,
             enforce_double_quotes=False,
             align_comments=False,
+            convert_flow_to_block=False,
             version=False,
             io_config=YamkixInputOutputConfig(input=None, output=None),
         )
@@ -91,6 +92,7 @@ class TestGetOpinionatedYamlWriter:
             enforce_double_quotes=False,
             line_width=CUSTOM_LINE_WIDTH_120,
             align_comments=False,
+            convert_flow_to_block=False,
             version=False,
             io_config=YamkixInputOutputConfig(input=None, output=None),
         )
@@ -120,6 +122,7 @@ class TestGetOpinionatedYamlWriter:
             enforce_double_quotes=False,
             line_width=DEFAULT_LINE_WIDTH,
             align_comments=False,
+            convert_flow_to_block=False,
             version=False,
             io_config=YamkixInputOutputConfig(input=None, output=None),
         )
@@ -146,6 +149,7 @@ class TestGetOpinionatedYamlWriter:
             enforce_double_quotes=False,
             line_width=DEFAULT_LINE_WIDTH,
             align_comments=False,
+            convert_flow_to_block=False,
             version=False,
             io_config=YamkixInputOutputConfig(input=None, output=None),
         )
@@ -175,6 +179,7 @@ class TestGetOpinionatedYamlWriter:
             enforce_double_quotes=False,
             line_width=custom_width,
             align_comments=False,
+            convert_flow_to_block=False,
             version=False,
             io_config=YamkixInputOutputConfig(input=None, output=None),
         )
@@ -199,6 +204,7 @@ class TestGetOpinionatedYamlWriter:
             enforce_double_quotes=False,
             line_width=CUSTOM_LINE_WIDTH_100,
             align_comments=False,
+            convert_flow_to_block=False,
             version=False,
             io_config=YamkixInputOutputConfig(input=None, output=None),
         )
@@ -228,6 +234,7 @@ class TestGetOpinionatedYamlWriter:
             enforce_double_quotes=True,
             line_width=CUSTOM_LINE_WIDTH_200,
             align_comments=False,
+            convert_flow_to_block=False,
             version=True,
             io_config=YamkixInputOutputConfig(input="test.yaml", output="output.yaml"),
         )
@@ -267,6 +274,7 @@ class TestGetOpinionatedYamlWriter:
             enforce_double_quotes=False,
             line_width=DEFAULT_LINE_WIDTH,
             align_comments=False,
+            convert_flow_to_block=False,
             version=False,
             io_config=YamkixInputOutputConfig(input=None, output=None),
         )
@@ -300,6 +308,7 @@ class TestGetOpinionatedYamlWriter:
             enforce_double_quotes=False,
             line_width=line_width,
             align_comments=False,
+            convert_flow_to_block=False,
             version=False,
             io_config=YamkixInputOutputConfig(input=None, output=None),
         )


### PR DESCRIPTION
## Summary

- Adds a new `-b` / `--convert-flow-to-block` CLI flag that converts flow-style (JSON-style) sequences and mappings to block style during formatting
- Implements `convert_flow_to_block_style()` in `helpers.py` — recursively walks `CommentedMap` / `CommentedSeq` nodes and calls `set_block_style()` on each
- Wires the flag through `YamkixConfig`, `create_yamkix_config_from_typer_args()`, and `yamkix_dump_all()` / `round_trip_and_format()`

## Test plan

- [ ] `tests/test_helpers.py` — unit tests for `convert_flow_to_block_style` covering sequences, mappings, nested structures, already-block-style inputs, and scalar pass-through
- [ ] `tests/test_yamkix.py` — integration tests confirming flow→block conversion changes content (`unchanged=False`) and that block input with flag disabled stays unchanged
- [ ] `tests/test_cli.py` — verifies `convert_flow_to_block` is passed through to `create_yamkix_config_from_typer_args`
- [ ] `tests/test_config.py` — verifies the flag is present in `YamkixConfig` and plumbed through `get_yamkix_config_from_default` / `create_yamkix_config_from_typer_args`
- [ ] All 172 tests pass; linters (`ruff`, `ty`, `pylint`, `pyright`) all clean