### PR TITLE
test(non_regression): add file-based tests for --convert-flow-to-block option

### DIFF
--- a/tests/data/expected/flow-sequences-and-maps--convert-flow-to-block.yml
+++ b/tests/data/expected/flow-sequences-and-maps--convert-flow-to-block.yml
@@ -1,0 +1,17 @@
+---
+a_list:
+  - a
+  - b
+  - c
+a_map:
+  first: yolo
+  second: foo
+nested:
+  inner_list:
+    - x
+    - y
+  inner_map:
+    a: 1
+already_block:
+  - item1
+  - item2

--- a/tests/data/expected/lists-and-maps-json-style--convert-flow-to-block.yml
+++ b/tests/data/expected/lists-and-maps-json-style--convert-flow-to-block.yml
@@ -1,0 +1,6 @@
+---
+a-map:
+  key1: value1
+  key2: value2
+a-json-map:
+  key1: value1

--- a/tests/data/source/flow-sequences-and-maps.yml
+++ b/tests/data/source/flow-sequences-and-maps.yml
@@ -1,0 +1,7 @@
+---
+a_list: [a, b, c]
+a_map: {first: yolo, second: foo}
+nested: {inner_list: [x, y], inner_map: {a: 1}}
+already_block:
+  - item1
+  - item2

--- a/tests/test_non_regression.py
+++ b/tests/test_non_regression.py
@@ -164,6 +164,18 @@ class TestNonRegression:
                 [],
                 id="issue_259_01_default_no_align",
             ),
+            pytest.param(
+                "lists-and-maps-json-style",
+                "convert-flow-to-block",
+                ["--convert-flow-to-block"],
+                id="lists_and_maps_json_style_convert_flow_to_block",
+            ),
+            pytest.param(
+                "flow-sequences-and-maps",
+                "convert-flow-to-block",
+                ["--convert-flow-to-block"],
+                id="flow_sequences_and_maps_convert_flow_to_block",
+            ),
         ],
     )
     def test_config(


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `tests/data/source/flow-sequences-and-maps.yml` — a source fixture covering flow sequences, flow mappings, nested flow structures, and already-block-style content
- Adds `tests/data/expected/flow-sequences-and-maps--convert-flow-to-block.yml` — expected output after applying `--convert-flow-to-block`
- Adds `tests/data/expected/lists-and-maps-json-style--convert-flow-to-block.yml` — expected output for the existing JSON-style source with `--convert-flow-to-block`
- Wires two new `pytest.param` entries into `TestNonRegression.test_config` in `tests/test_non_regression.py`

Total test count: 172 → 174 (all passing).

## Test plan

- [x] `uv run poe test` — 174 tests pass
- [x] `uv run poe lint:all` — ruff, ty, pylint, pyright all clean

https://claude.ai/code/session_01Q5mujYy8DSeij4XpXDJQV8
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5mujYy8DSeij4XpXDJQV8)_