### PR TITLE
fix(emitter): strip trailing spaces at line-width fold points (#437)

### DIFF
--- a/docs/explanation/yamllint-relaxed.md
+++ b/docs/explanation/yamllint-relaxed.md
@@ -60,19 +60,11 @@ In theory, yes: the `-w/--line-width` option sets the wrap width (default `2048`
 yamkix --input file.yml --line-width 80
 ```
 
-!!! warning "In practice, don't: you will trade a warning for errors"
+!!! note "Fold-point trailing spaces: fixed since 1.1.0"
 
-    The underlying `ruamel.yaml` emitter leaves a **trailing space at every fold point** when it wraps plain scalars and flow collections:
+    The underlying `ruamel.yaml` emitter leaves a **trailing space at every fold point** when it wraps plain scalars and flow collections — and `trailing-spaces` is an **error-level** rule in both the `default` and `relaxed` presets. Since yamkix 1.1.0 this artifact is stripped from the output ([issue #437](https://github.com/looztra/yamkix/issues/437)), so wrapped output no longer trips `trailing-spaces`.
 
-    ```yaml
-    description: this is a fairly long plain scalar value that will definitely␣
-      exceed the eighty character limit imposed by yamllint default and relaxed␣
-      presets
-    ```
-
-    Each `␣` is a real trailing space, and `trailing-spaces` is an **error-level** rule in both the `default` and `relaxed` presets — so wrapping converts a warning-level `line-length` finding into hard errors. Folded flow collections can additionally trip the `indentation` rule, and non-breakable tokens (long URLs…) still exceed the width anyway (tolerated by yamllint thanks to `allow-non-breakable-words: true`).
-
-    This is why yamkix ships with `line_width=2048`: until the emitter folds cleanly ([issue #437](https://github.com/looztra/yamkix/issues/437)), the right place to reconcile the two tools is the yamllint config, not the yamkix flag — see the companion config below.
+    Remaining caveats before reaching for `--line-width 80`: folded flow collections can trip the `indentation` rule (warning-level in relaxed), and non-breakable tokens (long URLs…) still exceed the width anyway (tolerated by yamllint thanks to `allow-non-breakable-words: true`). yamkix still ships with `line_width=2048` by default; if you prefer not to wrap, the yamllint side can be reconciled with the companion config below.
 
 ## Bottom line
 

--- a/src/yamkix/helpers.py
+++ b/src/yamkix/helpers.py
@@ -29,6 +29,37 @@ def strip_leading_double_space(stream: StreamType) -> StreamType:
     return stream.replace("\n  ", "\n")
 
 
+def strip_trailing_spaces(stream: StreamType) -> StreamType:
+    """Strip the spaces the emitter leaves at line-fold points.
+
+    Works around the `ruamel.yaml` emitter writing a space before deciding to
+    break a line (when the configured line width forces wrapping of plain
+    scalars or flow collections). Safe to apply to the whole emitted stream:
+    the emitter never puts a semantic space at end-of-line (scalars containing
+    a space followed by a line break are always emitted double-quoted with
+    escapes). See https://github.com/looztra/yamkix/issues/437.
+
+    Args:
+        stream: The emitted YAML document as a string.
+
+    Returns:
+        The stream with trailing spaces removed from every line.
+    """
+    return "\n".join(line.rstrip(" ") for line in stream.split("\n"))
+
+
+def strip_leading_double_space_and_trailing_spaces(stream: StreamType) -> StreamType:
+    """Apply both `strip_leading_double_space` and `strip_trailing_spaces`.
+
+    Args:
+        stream: The emitted YAML document as a string.
+
+    Returns:
+        The stream with leading double spaces and trailing spaces removed.
+    """
+    return strip_trailing_spaces(strip_leading_double_space(stream))
+
+
 def get_yamkix_version() -> str:
     """Get the current Yamkix version.
 

--- a/src/yamkix/yamkix.py
+++ b/src/yamkix/yamkix.py
@@ -15,7 +15,12 @@ from ruamel.yaml.scanner import ScannerError
 from yamkix.comments import align_comments, process_comments
 from yamkix.config import YamkixConfig
 from yamkix.errors import InvalidYamlContentError
-from yamkix.helpers import convert_flow_to_block_style, convert_single_to_double_quotes, strip_leading_double_space
+from yamkix.helpers import (
+    convert_flow_to_block_style,
+    convert_single_to_double_quotes,
+    strip_leading_double_space_and_trailing_spaces,
+    strip_trailing_spaces,
+)
 from yamkix.yaml_writer import get_opinionated_yaml_writer
 
 
@@ -196,6 +201,6 @@ def yamkix_dump_one(
     if spaces_before_comment is not None:
         process_comments(data=single_item, column=spaces_before_comment)
     if dash_inwards and type(single_item).__name__ == "CommentedSeq":
-        yaml.dump(data=single_item, stream=out, transform=strip_leading_double_space)
+        yaml.dump(data=single_item, stream=out, transform=strip_leading_double_space_and_trailing_spaces)
     else:
-        yaml.dump(data=single_item, stream=out)
+        yaml.dump(data=single_item, stream=out, transform=strip_trailing_spaces)

--- a/tests/data/expected/issue-437--default.yml
+++ b/tests/data/expected/issue-437--default.yml
@@ -1,0 +1,7 @@
+---
+description: this is a fairly long plain scalar value that will definitely exceed the eighty character limit imposed by yamllint default and relaxed presets
+a_list: [one, two, three, four, five, six, seven, eight, nine, ten, eleven, twelve, thirteen, fourteen]
+embedded_space_break: "line one \nline two"
+block: |
+  literal content
+  stays intact

--- a/tests/data/expected/issue-437--line-width-80.yml
+++ b/tests/data/expected/issue-437--line-width-80.yml
@@ -1,0 +1,10 @@
+---
+description: this is a fairly long plain scalar value that will definitely
+  exceed the eighty character limit imposed by yamllint default and relaxed
+  presets
+a_list: [one, two, three, four, five, six, seven, eight, nine, ten, eleven,
+      twelve, thirteen, fourteen]
+embedded_space_break: "line one \nline two"
+block: |
+  literal content
+  stays intact

--- a/tests/data/source/issue-437.yml
+++ b/tests/data/source/issue-437.yml
@@ -1,0 +1,7 @@
+---
+description: this is a fairly long plain scalar value that will definitely exceed the eighty character limit imposed by yamllint default and relaxed presets
+a_list: [one, two, three, four, five, six, seven, eight, nine, ten, eleven, twelve, thirteen, fourteen]
+embedded_space_break: "line one \nline two"
+block: |
+  literal content
+  stays intact

--- a/tests/integration/test_cli_subprocess.py
+++ b/tests/integration/test_cli_subprocess.py
@@ -79,6 +79,20 @@ class TestCliSubprocess:
         assert "input=STDIN" in result.stderr
         assert "output=STDOUT" in result.stderr
 
+    def test_line_width_output_has_no_trailing_spaces(self, datadir: Path) -> None:
+        """Test that wrapped lines produced by --line-width carry no trailing spaces (issue #437)."""
+        # GIVEN
+        source = datadir / "issue-437.yml"
+        expected = datadir / "issue-437--line-width-80.yml"
+
+        # WHEN
+        result = run_yamkix(["--input", str(source), "--output", "STDOUT", "--line-width", "80"])
+
+        # THEN
+        assert result.returncode == 0
+        assert result.stdout == expected.read_text()
+        assert not any(line.endswith(" ") for line in result.stdout.splitlines())
+
     def test_stdin_silent(self, datadir: Path) -> None:
         """Test that STDIN input in silent mode does not print the config banner to stderr."""
         # GIVEN

--- a/tests/integration/test_cli_subprocess/issue-437--line-width-80.yml
+++ b/tests/integration/test_cli_subprocess/issue-437--line-width-80.yml
@@ -1,0 +1,10 @@
+---
+description: this is a fairly long plain scalar value that will definitely
+  exceed the eighty character limit imposed by yamllint default and relaxed
+  presets
+a_list: [one, two, three, four, five, six, seven, eight, nine, ten, eleven,
+      twelve, thirteen, fourteen]
+embedded_space_break: "line one \nline two"
+block: |
+  literal content
+  stays intact

--- a/tests/integration/test_cli_subprocess/issue-437.yml
+++ b/tests/integration/test_cli_subprocess/issue-437.yml
@@ -1,0 +1,7 @@
+---
+description: this is a fairly long plain scalar value that will definitely exceed the eighty character limit imposed by yamllint default and relaxed presets
+a_list: [one, two, three, four, five, six, seven, eight, nine, ten, eleven, twelve, thirteen, fourteen]
+embedded_space_break: "line one \nline two"
+block: |
+  literal content
+  stays intact

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -3,6 +3,7 @@
 from io import StringIO
 from textwrap import dedent
 
+import pytest
 from ruamel.yaml import YAML
 from ruamel.yaml.scalarstring import DoubleQuotedScalarString, SingleQuotedScalarString
 
@@ -13,6 +14,8 @@ from yamkix.helpers import (
     remove_all_linebreaks,
     string_is_comment,
     strip_leading_double_space,
+    strip_leading_double_space_and_trailing_spaces,
+    strip_trailing_spaces,
 )
 
 
@@ -132,6 +135,31 @@ def test_strip_leading_double_space_when_none() -> None:
     stream = "text1\ntext2\n"
     actual = strip_leading_double_space(stream)
     assert actual == stream
+
+
+@pytest.mark.parametrize(
+    ("stream", "expected"),
+    [
+        pytest.param("text1 \n  text2 \n", "text1\n  text2\n", id="fold_point_trailing_spaces"),
+        pytest.param("text1\ntext2\n", "text1\ntext2\n", id="no_trailing_spaces"),
+        pytest.param("text1   \n", "text1\n", id="multiple_trailing_spaces"),
+        pytest.param("text1 ", "text1", id="no_trailing_newline"),
+        pytest.param("", "", id="empty_stream"),
+        pytest.param('quoted: "line one \\nline two"\n', 'quoted: "line one \\nline two"\n', id="escaped_space_kept"),
+    ],
+)
+def test_strip_trailing_spaces(stream: str, expected: str) -> None:
+    """Test strip_trailing_spaces removes end-of-line spaces without touching anything else."""
+    assert strip_trailing_spaces(stream) == expected
+
+
+def test_strip_leading_double_space_and_trailing_spaces() -> None:
+    """Test the composition of strip_leading_double_space and strip_trailing_spaces."""
+    stream = "  text1 \n  text2  \ntext3\n"
+
+    actual = strip_leading_double_space_and_trailing_spaces(stream)
+    expected = "text1\ntext2\ntext3\n"
+    assert actual == expected
 
 
 def test_get_yamkix_version() -> None:

--- a/tests/test_non_regression.py
+++ b/tests/test_non_regression.py
@@ -206,6 +206,18 @@ class TestNonRegression:
                 ["--enforce-block-style"],
                 id="lists_and_maps_json_style_enforce_block_style",
             ),
+            pytest.param(
+                "issue-437",
+                "line-width-80",
+                ["--line-width", "80"],
+                id="issue_437_line_width_80_no_trailing_spaces",
+            ),
+            pytest.param(
+                "issue-437",
+                "default",
+                [],
+                id="issue_437_default",
+            ),
         ],
     )
     def test_config(


### PR DESCRIPTION
## Summary

When `-w/--line-width` is low enough that the emitter folds lines, `ruamel.yaml` leaves a trailing space at every fold point in plain scalars and flow collections, turning a warning-level `line-length` yamllint finding into error-level `trailing-spaces` errors. This PR strips those fold-point spaces from all emitted output via the existing `transform` hook.

## Changes

- Add `strip_trailing_spaces` transform in `helpers.py` (line-wise `rstrip(" ")`), plus a named composition with the existing `strip_leading_double_space`
- Apply a transform on every dump in `yamkix_dump_one` (previously only the dash-inwards `CommentedSeq` branch had one)
- Unit tests for both new helpers, including an escaped-space (`\"line one \\nline two\"`) case proving quoted scalars are untouched
- New non-regression assets (`issue-437.yml` source + `--line-width-80` / `--default` expected) and two parametrized cases
- New subprocess integration test + datadir assets asserting byte-exact output and no line ending with a space
- Docs: the yamllint-comparison caveat from #436 now records the fix

## Safety

A blanket line-wise strip is safe by construction: the emitter never emits a semantic space at end-of-line — scalars containing space-before-break are always double-quoted with escapes, verified by test assets covering quoted and literal-block scalars. Output was also checked semantically identical (`safe_load` before == after).

## Test plan

- `uv run poe test` — 201 passed
- `uv run poe lint:all` — ruff, ty, pylint (10/10), pyright all clean
- Issue repro re-run through `cat -A`: no trailing spaces

Closes #437

🤖 Generated with [Claude Code](https://claude.com/claude-code)