### PR TITLE
feat(renovate): add 7 day cooldown for python, actions, and pre-commit updates

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -12,4 +12,16 @@
     enabled: true,
     automerge: true
   },
+  packageRules: [
+    {
+      matchManagers: [
+        "pep621",
+        "pip_requirements",
+        "uv",
+        "github-actions",
+        "pre-commit"
+      ],
+      minimumReleaseAge: "7 days"
+    }
+  ],
 }


### PR DESCRIPTION
## Summary
- Add a `packageRules` entry to `renovate.json5` setting `minimumReleaseAge: "7 days"`
- Scoped to the Python managers (`pep621`, `pip_requirements`, `uv`), `github-actions`, and `pre-commit`, so Renovate waits 7 days after a release is published before proposing an update for those ecosystems

## Test plan
- [x] Validated `renovate.json5` parses as valid JSON5
- [ ] Confirm Renovate dashboard picks up the new `minimumReleaseAge` rule after merge


---
_Generated by [Claude Code](https://claude.ai/code/session_01NaWgmjy91Fzt93ZVSQdMi6)_