### PR TITLE
ci(workflows): add CodeQL analysis for python and actions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,48 @@
+---
+name: CodeQL
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+    types: [opened, synchronize, reopened, ready_for_review]
+  schedule:
+    - cron: 26 7 * * 1
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write # required to upload CodeQL results
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - actions
+          - python
+
+    steps:
+      - name: Checkout current branch
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        with:
+          category: /language:${{ matrix.language }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,7 +58,7 @@ repos:
     rev: v1.1.0
     hooks:
       - id: yamkix
-        args: [--no-quotes-preserved]
+        args: [--no-quotes-preserved, --silent]
         exclude: |
           (?x)^(
               tests/data/.*|


### PR DESCRIPTION
## Summary

Adds CodeQL code scanning via advanced setup (versioned workflow), covering the two languages GitHub detects in this repo: `python` and `actions`.

## Changes

- New `.github/workflows/codeql.yml`:
  - Runs on pushes and PRs to `main`, plus a weekly Monday schedule to pick up newly published queries
  - Matrix over `python` and `actions`, both with `build-mode: none` (no dependency install needed)
  - Minimal permissions (`contents: read`, `security-events: write`), pinned action SHAs, `persist-credentials: false` — consistent with the zizmor-hardened workflows from #448

## Verification

- `zizmor` v1.26.1: no findings
- CodeQL checks will appear on this PR once the workflow runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)