### PR TITLE
chore(github): AI-readiness pass — issue/PR templates, AGENTS.md expansion

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,69 @@
+---
+name: Bug Report
+description: Report unexpected or incorrect yamkix formatting behavior
+title: 'fix(): '
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug! Please fill out the sections below so it can be reproduced quickly.
+
+  - type: input
+    id: version
+    attributes:
+      label: yamkix version
+      description: Output of `yamkix --version` (or `--v`)
+      placeholder: yamkix v1.1.0
+    validations:
+      required: true
+
+  - type: input
+    id: python-version
+    attributes:
+      label: Python version
+      description: Output of `python --version`
+      placeholder: Python 3.12.4
+    validations:
+      required: true
+
+  - type: input
+    id: command
+    attributes:
+      label: Command used
+      description: The exact yamkix invocation, including flags
+      placeholder: yamkix -i input.yaml -o output.yaml --enforce-double-quotes
+    validations:
+      required: true
+
+  - type: textarea
+    id: input-yaml
+    attributes:
+      label: Input YAML
+      description: The smallest YAML snippet that reproduces the issue
+      render: yaml
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected output
+      render: yaml
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual output
+      render: yaml
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: OS, shell, or anything else that might be relevant

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+---
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation
+    url: https://looztra.github.io/yamkix/
+    about: Check the docs (tutorials, how-to guides, reference) before opening an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,41 @@
+---
+name: Feature Request
+description: Suggest a new yamkix flag, formatting option, or behavior
+title: 'feat(): '
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement! Please describe the motivation and desired behavior.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: What formatting behavior or workflow is currently missing or awkward?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: >
+        Describe the new CLI flag or behavior you'd like. If it's a flag, suggest a name (e.g.
+        `--no-dash-inwards`) consistent with yamkix's existing `--flag-name` / `-x` convention.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any workarounds you're currently using, or other approaches you considered
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Example input/output YAML, links to related issues, etc.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+# Pull Request
+
+## Description
+
+<!-- What does this PR change and why? -->
+
+Fixes #<!-- issue number, if any -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature / CLI flag
+- [ ] Documentation
+- [ ] Chore / tooling
+
+## How has this been tested?
+
+- [ ] `uv run poe test` (or `poe test:cov`) passes
+- [ ] `uv run poe lint:all` passes (`ruff`, `ty`, `pylint`, `pyright`)
+- [ ] Added/updated tests in `tests/` covering the change
+
+## Checklist
+
+- [ ] PR title follows Conventional Commits with a scope (e.g. `feat(cli): add flag`, `fix(config): handle edge case`)
+- [ ] Docs updated under `docs/` if user-facing behavior changed (no manual changelog edit — `release-please` handles it)
+- [ ] Verification plan and results included above

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,14 @@ This document provides context and instructions for AI agents working on this re
 - **Language**: Python (managed via `uv`)
 - **Main Branch**: `main`
 
+## Repository Structure
+
+- `src/yamkix/` — package source: `_cli.py` (Typer app), `config.py` (`YamkixConfig`/`YamkixInputOutputConfig`), `yamkix.py` (core formatting), `yaml_writer.py` (ruamel.yaml setup), `comments.py` (comment handling), `helpers.py`, `errors.py`, `args.py`.
+- `tests/` — unit tests (`test_*.py`) plus `tests/integration/` (marked `@pytest.mark.integration`, excluded from `poe test:cov`).
+- `docs/` — mkdocs Diataxis site (`tutorials/`, `how-to/`, `reference/`, `explanation/`), published by `.github/workflows/publish_docs.yml`.
+- `toolbox/mise/` and `toolbox/mk/` — shared `mise` task definitions and Makefile includes.
+- `experiments/` — scratch/exploratory scripts, not part of the package or CI.
+
 ## Workflow & Standards
 
 ### Commit & Pull Requests
@@ -63,6 +71,30 @@ This project uses `poethepoet` for task management. Common tasks:
 - **Configuration**: Managed in `src/yamkix/config.py`.
 - **CLI**: Implemented using `typer` in `src/yamkix/_cli.py`.
 - **YAML Handling**: Uses `ruamel.yaml` in `src/yamkix/yamkix.py` and `src/yamkix/yaml_writer.py`.
+
+## CI/CD
+
+- **`.github/workflows/code_checks.yml`**: pre-commit checks, Python lint+test (`mise run lint` / `mise run test`), distribution build check, mkdocs build check, integration tests, and release-please-driven publish to (Test)PyPI on release runs.
+- **`.github/workflows/release_please.yml`**: drives `docs/changelog.md`, `version.txt`, and `.release-please-manifest.json` via conventional-commit history — never edit these by hand.
+- **`.github/workflows/lint_pr_titles.yml`**: enforces conventional-commit PR titles (scope required, matching this file's commit convention).
+- **`.github/workflows/codeql.yml`** and **`workflows_checks.yml`**: security/workflow linting (CodeQL, `zizmor`, `actionlint`).
+- **Dependency updates**: `renovate.json5` covers Python/tool deps; `.github/dependabot.yml` covers GitHub Actions only (weekly).
+
+## Adding a New CLI Flag
+
+1. Add the `typer.Option` parameter to `main()` in `src/yamkix/_cli.py`.
+2. Forward it as a kwarg to `create_yamkix_config_from_typer_args()` in `src/yamkix/config.py`.
+3. Add/extend the corresponding field on `YamkixConfig` (or `YamkixInputOutputConfig` for I/O flags) in `config.py`.
+4. Consume the field where formatting happens: `yaml_writer.py` (writer-level settings), `yamkix.py` (`round_trip_and_format`), or `comments.py` (comment behavior).
+5. Add/extend tests in `tests/test_cli.py` (flag parsing) and `tests/test_config.py` (config construction).
+6. Document the flag in `docs/reference/` and/or `docs/how-to/`.
+
+## Common Pitfalls
+
+- Don't hand-edit `version.txt` or `docs/changelog.md` — both are managed by `release-please`.
+- `enforce_double_quotes` requires a two-pass round trip (see `yamkix.py`) — don't collapse it into a single pass.
+- Integration tests are excluded from `poe test:cov` (`-m 'not integration'`); run them explicitly with `pytest -m integration` or `mise run test:integration`.
+- `.python-version` (3.14) is the dev/CI runtime; `requires-python = ">=3.10"` and the trove classifiers (3.10–3.12) define supported runtimes — they are not the same thing.
 
 ## General Guidelines for Agents
 


### PR DESCRIPTION
## Description

Closes the AI-readiness gaps identified by an ai-ready audit, excluding Copilot-specific assets and `.mcp.json` (skipped per request).

## Changes

- `AGENTS.md`: add Repository Structure, CI/CD, "Adding a New CLI Flag", and Common Pitfalls sections (previously only covered commit/style/testing conventions).
- `.github/ISSUE_TEMPLATE/bug_report.yml` + `feature_request.yml` + `config.yml`: structured issue forms tailored to yamkix (version, Python version, exact command, input/expected/actual YAML).
- `.github/PULL_REQUEST_TEMPLATE.md`: description/type-of-change/testing/checklist template referencing the project's actual commands (`poe test`, `poe lint:all`) and conventions (conventional-commit scope, no manual changelog edits since `release-please` owns it).

## Not included (explicitly skipped)

- `.github/copilot-instructions.md` / maintenance matrix
- `.mcp.json`
- `.github/workflows/copilot-setup-steps.yml`

## How to test

- `markdownlint-cli2 AGENTS.md .github/PULL_REQUEST_TEMPLATE.md` → 0 issues
- YAML issue forms parsed successfully with `yaml.safe_load`

Assisted by [ai-ready](https://github.com/johnpapa/ai-ready)