### PR TITLE
fix(pre-commit): drop stray .git suffix from yamllint repo url

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
       - id: shellcheck # Shell scripts conform to shellcheck
       - id: shfmt # Check shell style with shfmt
 
-  - repo: https://github.com/adrienverge/yamllint.git
+  - repo: https://github.com/adrienverge/yamllint
     rev: v1.38.0
     hooks:
       - id: yamllint


### PR DESCRIPTION
# Pull Request

## Description

Zizmor 1.30.0 (pulled in transitively via the `zizmorcore/zizmor-action` `v0.6.2` → `v0.6.3` bump in #511) extended the `ref-confusion` audit to also cover `.pre-commit-config.yaml`. It resolves each `repo:` URL to a GitHub `owner/repo` path and calls the GitHub API to list branches.

The `adrienverge/yamllint` entry in `.pre-commit-config.yaml` was the only `repo:` in the file with a trailing `.git` suffix. Zizmor includes that suffix literally in the API path (`GET /repos/adrienverge/yamllint.git/branches` → `404 Not Found`), which it maps to `can't access adrienverge/yamllint.git: missing or you have no access` and treats as fatal — breaking the `Check the repository github actions workflows` CI job on every PR (including #511) once the action bump lands.

This is **not** a `GITHUB_TOKEN` scope/permissions issue: `adrienverge/yamllint` is public, and the failure reproduces identically running `zizmor` 1.30.0 locally, anonymously, against this repo. Dropping the stray `.git` suffix — matching every other `repo:` entry in this file — fixes it.

Fixes N/A (no tracked issue; discovered while diagnosing why #511's CI check fails).

## Type of change

- [x] Bug fix
- [ ] New feature / CLI flag
- [ ] Documentation
- [ ] Chore / tooling

## How has this been tested?

- [x] `uv run poe test` (or `poe test:cov`) passes
- [x] `uv run poe lint:all` passes (`ruff`, `ty`, `pylint`, `pyright`)
- [ ] Added/updated tests in `tests/` covering the change

No test added: this is a static-config fix with no application code path to unit-test. Verified instead by running the actual failing tool directly:

- Before fix: `zizmor .pre-commit-config.yaml` (zizmor v1.30.0, matching the pinned CI image) → `fatal: no audit was performed` / `couldn't list branches for adrienverge/yamllint.git` / `can't access adrienverge/yamllint.git: missing or you have no access`.
- After fix: `zizmor .` (full repo, mirroring `.github/workflows/workflows_checks.yml`) → `No findings to report. Good job! (12 ignored, 19 suppressed)`.
- `uv run pre-commit run yamllint --all-files` → hook still resolves/clones `adrienverge/yamllint` and passes, confirming the URL change doesn't break pre-commit itself.

## Checklist

- [x] PR title follows Conventional Commits with a scope (e.g. `feat(cli): add flag`, `fix(config): handle edge case`)
- [ ] Docs updated under `docs/` if user-facing behavior changed (no manual changelog edit — `release-please` handles it)
- [x] Verification plan and results included above
